### PR TITLE
feat: add Go GOPATH/bin to PATH for go install tools

### DIFF
--- a/dotfiles/.bashrc.ftw
+++ b/dotfiles/.bashrc.ftw
@@ -184,6 +184,11 @@ export PS1="\[\033[01;90m\][\t] \[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]
 
 # local scripts and /usr/local/bin, /usr/local/sbin
 PATH=$HOME/bin:$HOME/.local/bin:$PATH:/usr/local/sbin:/usr/local/bin
+
+# Go: Add GOPATH/bin to PATH for tools installed via `go install`
+# (e.g., goimports, golint, etc.)
+PATH="$PATH:$(go env GOPATH 2>/dev/null)/bin"
+
 export PATH
 
 # Emacs is the best:


### PR DESCRIPTION
## Summary
Add Go's `$GOPATH/bin` to PATH so tools installed via `go install` are available.

Fixes common error when using Go tools like `goimports`:
```
make: goimports: No such file or directory
```

## Changes
- Add `$(go env GOPATH)/bin` to PATH in exports section
- Uses `2>/dev/null` to suppress errors if Go isn't installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)